### PR TITLE
Fix division by zero with weights of zero

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -325,6 +325,15 @@
             throw new RangeError("Chance: length of array and weights must match");
         }
 
+        // Handle weights that are less or equal to zero.
+        for (var weightIndex = weights.length - 1; weightIndex >= 0; --weightIndex) {
+            // If the weight is less or equal to zero, remove it and the value.
+            if (weights[weightIndex] <= 0) {
+                arr.splice(weightIndex,1);
+                weights.splice(weightIndex,1);
+            }
+        }
+
         // If any of the weights are less than 1, we want to scale them up to whole
         //   numbers for the rest of this logic to work
         if (weights.some(function(weight) { return weight < 1; })) {

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -133,6 +133,16 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
                     expect((picked.c / picked.b) * 100).to.be.within(50, 150);
                 });
             });
+
+            it("works with weights of 0", function () {
+                picked = chance.weighted(['a', 'b', 'c'], [1, 0, 1]);
+                expect(picked).to.be.a('string');
+            });
+
+            it("works with negative weights", function () {
+                picked = chance.weighted(['a', 'b', 'c'], [1, -2, 1]);
+                expect(picked).to.be.a('string');
+            });
         });
 
         describe("shuffle()", function () {


### PR DESCRIPTION
Providing a weight of 0 to weighted() would cause a division by zero and ultimately failure of the helper.
Fixes #138