### PR TITLE
JSHint cleanup, fixes, and improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,24 +4,34 @@ module.exports = function (grunt) {
     grunt.initConfig({
         jshint: {
             options: {
+                // Enforcing
                 curly: true,
                 eqeqeq: true,
-                expr: true,
                 immed: true,
                 indent: 4,
                 latedef: true,
                 newcap: true,
                 noarg: true,
-                sub: true,
-                trailing: true,
+                undef: true,
+                unused: true,
+
+                // Relaxing
                 boss: true,
                 eqnull: true,
+                expr: true,
+                sub: true,
+
+                // Environments
                 browser: true,
-                white: false
-            },
-            globals: {
-                exports: true,
-                module: false
+                mocha: true,
+                node: true,
+
+                // Custom Globals
+                globals: {
+                    define: false,
+                    mochaPhantomJS: false,
+                    chance: true
+                }
             },
             all: js_files
         },

--- a/chance.js
+++ b/chance.js
@@ -29,7 +29,7 @@
         }
 
         var seedling;
-        
+
         if (arguments.length) {
             // set a starting value of zero so we can add to it
             this.seed = 0;
@@ -82,9 +82,8 @@
 
     /**
      * Encode the input string with Base64.
-     * @param input
      */
-    var base64 = function(input) {
+    var base64 = function() {
         throw new Error('No Base64 encoder available.');
     };
 
@@ -266,10 +265,9 @@
      *  Gives an array of n random terms
      *  @param fn the function that generates something random
      *  @param n number of terms to generate
-     *  @param options options for the function fn. 
      *  There can be more parameters after these. All additional parameters are provided to the given function
      */
-    Chance.prototype.n = function(fn, n, options) {
+    Chance.prototype.n = function(fn, n) {
         var i = n || 1, arr = [], params = slice.call(arguments, 2);
         // Providing a negative count should result in a noop.
         i = Math.max( 0, i );
@@ -634,27 +632,27 @@
 
     // -- Mobile --
     // Android GCM Registration ID
-    Chance.prototype.android_id = function (options) {
+    Chance.prototype.android_id = function () {
         return "APA91" + this.string({ pool: "0123456789abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_", length: 178 });
     };
 
     // Apple Push Token
-    Chance.prototype.apple_token = function (options) {
+    Chance.prototype.apple_token = function () {
         return this.string({ pool: "abcdef1234567890", length: 64 });
     };
 
     // Windows Phone 8 ANID2
-    Chance.prototype.wp8_anid2 = function (options) {
+    Chance.prototype.wp8_anid2 = function () {
         return base64( this.hash( { length : 32 } ) );
     };
 
     // Windows Phone 7 ANID
-    Chance.prototype.wp7_anid = function (options) {
+    Chance.prototype.wp7_anid = function () {
         return 'A=' + this.guid().replace(/-/g, '').toUpperCase() + '&E=' + this.hash({ length:3 }) + '&W=' + this.integer({ min:0, max:9 });
     };
 
     // BlackBerry Device PIN
-    Chance.prototype.bb_pin = function (options) {
+    Chance.prototype.bb_pin = function () {
         return this.hash({ length: 8 });
     };
 
@@ -1294,7 +1292,7 @@
                    this.string({ pool: guid_pool, length: 12 });
         return guid;
     };
-    
+
     // Hash
     Chance.prototype.hash = function (options) {
         options = initOptions(options, {length : 40, casing: 'lower'});
@@ -1686,6 +1684,7 @@
 
     function _copyObject(source, target) {
       var keys = o_keys(source);
+      var key;
 
       for (var i = 0, l = keys.length; i < l; i++) {
         key = keys[i];

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-bump": "0.0.11",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "0.5.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-mocha-phantomjs": "0.5.0",

--- a/test/base.js
+++ b/test/base.js
@@ -26,8 +26,7 @@ require.config({
     }
 });
 
-require(['mocha', 'chai'], function (mocha, chai) {
-    var assert = chai.assert;
+require(['mocha', 'chai'], function (mocha) {
     require(['test.address', 'test.basic', 'test.finance', 'test.helpers', 'test.misc', 'test.person', 'test.text', 'test.time', 'test.web', 'test.mobile'], function () {
         mocha.reporter('html');
 

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -1,9 +1,8 @@
 define(['Chance', 'mocha', 'chai', 'underscore', 'phoneTest'], function (Chance, mocha, chai, _, phoneTest) {
-    var assert = chai.assert,
-        expect = chai.expect;
+    var expect = chai.expect;
 
     describe("Address", function () {
-        var zip, suffix, suffixes, state, address, phone, coordinates, country, chance = new Chance();
+        var zip, suffix, suffixes, state, address, country, chance = new Chance();
 
         describe("Zip", function () {
             it("returns a valid basic zip code", function () {

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -185,7 +185,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
                     });
                 });
 
-                _.forEach(positions, function(position, index) {
+                _.forEach(positions, function(position) {
                     _.forEach(position, function(item) {
                         // This should be around 20% give or take a bit since there are
                         // 5 elements and they should be evenly distributed
@@ -249,7 +249,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
                 expect(arr.length).to.equal(1);
             });
         });
-        
+
         describe("pad()", function () {
             it("always returns same number when width same as the length of the number", function () {
                 _(1000).times(function () {

--- a/test/test.misc.js
+++ b/test/test.misc.js
@@ -233,6 +233,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
 
     describe("CNPJ", function () {
         var chance = new Chance();
+        var cnpj;
 
         it("returns a valid Brazil company ID (CNPJ)", function () {
             _(1000).times(function () {

--- a/test/test.person.js
+++ b/test/test.person.js
@@ -2,7 +2,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
     var expect = chai.expect;
 
     describe("Person", function () {
-        var age, name, first, last, prefix, suffix, ssn, chance = new Chance();
+        var name, first, last, prefix, suffix, ssn, chance = new Chance();
 
         describe("age()", function () {
             it("returns a random age within expected bounds", function () {
@@ -175,6 +175,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
         });
 
         describe("cpf()", function () {
+            var cpf;
             it("returns a random valid taxpayer number for Brazil citizens (CPF)", function () {
                 _(1000).times(function () {
                     cpf = chance.cpf();

--- a/test/test.time.js
+++ b/test/test.time.js
@@ -2,7 +2,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
     var expect = chai.expect;
 
     describe("Time", function () {
-        var date, hour, minute, time, timestamp, month, year, bounds, chance = new Chance();
+        var date, hour, minute, timestamp, month, year, bounds, chance = new Chance();
 
         it("date() returns a date", function () {
             _(1000).times(function () {


### PR DESCRIPTION
This PR includes a lib bump for `grunt-contrib-jshint` as well as general JSHint updates and cleanup.

- Removing deprecated JSHint options
- Adding `undef: true` & `unused: true` Enforcements
- Code cleanup