### PR TITLE
when Chance called as function, only call new chance with seed if defined, and use random integer instead of time when no seed specified for twister

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -19,7 +19,7 @@
     // Constructor
     function Chance (seed) {
         if (!(this instanceof Chance)) {
-            return new Chance(seed);
+            return seed == null ? new Chance() : new Chance(seed);
         }
 
         // if user has provided a function, use that as the generator
@@ -1826,7 +1826,8 @@
     // Mersenne Twister from https://gist.github.com/banksean/300494
     var MersenneTwister = function (seed) {
         if (seed === undefined) {
-            seed = new Date().getTime();
+            // kept random number same size as time used previously to ensure no unexpected results downstream
+            seed = Math.floor(Math.random()*Math.pow(10,13));
         }
         /* Period parameters */
         this.N = 624;


### PR DESCRIPTION
Problem... calling `Chance` without `seed` results in passing `undefined` as seed, and therefore similar outputs. Executing...

    console.log([Chance().random(),Chance().random(),Chance().random(),Chance().random()])

... results in ...

    [0.548813502304256, 0.548813502304256, 0.548813502304256, 0.548813502304256]

If we change that to call chance with `seed` only if defined, we get...

    [0.901146336691454, 0.249545892002061, 0.3616938649211079, 0.3616938649211079]

... which is much better, but there is still a problem. Last two items are identical. Seems that when `MersenneTwister` is initialised without `seed`, it uses microsecond resolution timestamp as seed - so two calls in the same microsecond produce the exact same result. By changing the seed definition (when not specified as parameter) to be based on `Math.random`, the results are no longer purely time based, so subsequent calls don't repeat...

    [0.02894203527830541, 0.742930015316233, 0.6635597355198115, 0.3085388035979122]

... now, to my naked eye, that looks a lot more random - and much more suitable for using to generate some random strings :-)

Although it could be argued that `Math.random` is not perfectly evenly distributed, if a better random seed is needed, it can still be simply provided.