### PR TITLE
Add newline to output if stdout/err is a tty

### DIFF
--- a/bin/chance.js
+++ b/bin/chance.js
@@ -12,6 +12,8 @@ var chance = new Chance(new Date().getTime().toString());
 if(generator && chance[generator]) {
     // Invoke the generator on our Chance instance and print the result.
     process.stdout.write(chance[generator](options));
+    if (process.stdout.isTTY) process.stdout.write('\n');
 } else {
     process.stderr.write('Unknown generator "' + generator + '"');
+    if (process.stderr.isTTY) process.stderr.write('\n');
 }


### PR DESCRIPTION
If stdout/stderr is a TTY, emit a newline so that running the CLI from the prompt still looks nice. Piping into another process (head, less, etc.) will still omit the newline.