### PR TITLE
Bug/date() generating wrong month

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1011,13 +1011,19 @@
             date = new Date(this.natural({min: min, max: max}));
         } else {
             var m = this.month({raw: true});
+            var daysInMonth = m.days;
+
+            if(options && options.month) {
+                // Mod 12 to allow months outside range of 0-11 (not encouraged, but also not prevented).
+                daysInMonth = this.get('months')[((options.month % 12) + 12) % 12].days;
+            }
 
             options = initOptions(options, {
                 year: parseInt(this.year(), 10),
                 // Necessary to subtract 1 because Date() 0-indexes month but not day or year
                 // for some reason.
                 month: m.numeric - 1,
-                day: this.natural({min: 1, max: m.days}),
+                day: this.natural({min: 1, max: daysInMonth}),
                 hour: this.hour(),
                 minute: this.minute(),
                 second: this.second(),

--- a/test/test.time.js
+++ b/test/test.time.js
@@ -14,13 +14,16 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
 
         it("date() can have some defaults provided and obeys them", function () {
             _(1000).times(function () {
+                // One of each month type in terms of number of days.
+                var month = [0, 1, 3][Math.floor(Math.random() * 3)];
+
                 date = chance.date({year: 1983});
                 expect(date).to.be.a('Date');
                 expect(date.getFullYear()).to.equal(1983);
 
-                date = chance.date({month: 0});
+                date = chance.date({month: month});
                 expect(date).to.be.a('Date');
-                expect(date.getMonth()).to.equal(0);
+                expect(date.getMonth()).to.equal(month);
 
                 date = chance.date({day: 21});
                 expect(date).to.be.a('Date');


### PR DESCRIPTION
Bug:
The generated date is occasionally one month ahead from the static month value. This can happen when the static month is one with less than 31 days.

E.g.: `chance.date({month:1})` will generate a date in March ~10% of the time.