### PR TITLE
Add md5() and avatar() methods

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,7 +53,8 @@ module.exports = function (grunt) {
                     define: false,
                     mocha: true,
                     mochaPhantomJS: false,
-                    phoneNumber: true
+                    phoneNumber: true,
+                    unescape: true
                 }
             },
             all: js_files

--- a/chance.js
+++ b/chance.js
@@ -1000,10 +1000,6 @@
         return options.protocol + "://" + domain + "/" + options.path + extension;
     };
 
-    // Chance.prototype.avatar = function(options) {
-
-    // }
-
     // -- End Web --
 
     // -- Location --

--- a/chance.js
+++ b/chance.js
@@ -50,6 +50,7 @@
 
         // If no generator function was provided, use our MT
         this.mt = this.mersenne_twister(this.seed);
+        this.bimd5 = this.blueimp_md5();
         this.random = function () {
             return this.mt.random(this.seed);
         };
@@ -808,6 +809,87 @@
     // -- End Mobile --
 
     // -- Web --
+    Chance.prototype.avatar = function (options) {
+        var url = null;
+        var URL_BASE = '//www.gravatar.com/avatar/';
+        var PROTOCOLS = {
+            http: 'http',
+            https: 'https'
+        };
+        var FILE_TYPES = {
+            bmp: 'bmp',
+            gif: 'gif',
+            jpg: 'jpg',
+            png: 'png'
+        };
+        var FALLBACKS = {
+            '404': '404', // Return 404 if not found
+            mm: 'mm', // Mystery man
+            identicon: 'identicon', // Geometric pattern based on hash
+            monsterid: 'monsterid', // A generated monster icon
+            wavatar: 'wavatar', // A generated face
+            retro: 'retro', // 8-bit icon
+            blank: 'blank' // A transparent png
+        };
+        var RATINGS = {
+            g: 'g',
+            pg: 'pg',
+            r: 'r',
+            x: 'x'
+        };
+        var opts = {
+            protocol: null,
+            email: null,
+            fileExtension: null,
+            size: null,
+            fallback: null,
+            rating: null
+        };
+
+        if (!options) {
+            // Set to a random email
+            opts.email = this.email();
+            options = {};
+        }
+        else if (typeof options === 'string') {
+            opts.email = options;
+            options = {};
+        }
+        else if (typeof options !== 'object') {
+            return null;
+        }
+        else if (options.constructor === 'Array') {
+            return null;
+        }
+
+        opts = initOptions(options, opts);
+
+        if (!opts.email) {
+            // Set to a random email
+            opts.email = this.email();
+        }
+
+        // Safe checking for params
+        opts.protocol = PROTOCOLS[opts.protocol] ? opts.protocol + ':' : '';
+        opts.size = parseInt(opts.size, 0) ? opts.size : '';
+        opts.rating = RATINGS[opts.rating] ? opts.rating : '';
+        opts.fallback = FALLBACKS[opts.fallback] ? opts.fallback : '';
+        opts.fileExtension = FILE_TYPES[opts.fileExtension] ? opts.fileExtension : '';
+
+        url =
+            opts.protocol +
+            URL_BASE +
+            this.bimd5.md5(opts.email) +
+            (opts.fileExtension ? '.' + opts.fileExtension : '') +
+            (opts.size || opts.rating || opts.fallback ? '?' : '') +
+            (opts.size ? '&s=' + opts.size.toString() : '') +
+            (opts.rating ? '&r=' + opts.rating : '') +
+            (opts.fallback ? '&d=' + opts.fallback : '')
+            ;
+
+        return url;
+    };
+
     Chance.prototype.color = function (options) {
         function gray(value, delimiter) {
             return [value, value, value].join(delimiter || '');
@@ -917,6 +999,10 @@
 
         return options.protocol + "://" + domain + "/" + options.path + extension;
     };
+
+    // Chance.prototype.avatar = function(options) {
+
+    // }
 
     // -- End Web --
 
@@ -1496,6 +1582,29 @@
         return (sum * 9) % 10;
     };
 
+    // MD5 Hash
+    Chance.prototype.md5 = function(options) {
+        var opts = { str: "", key: null, raw: false };
+
+        if(typeof options === 'string') {
+            opts.str = options;
+            options = {};
+        }
+        else if (typeof options !== 'object') {
+            return null;
+        }
+        else if(options.constructor === 'Array') {
+            return null;
+        }
+
+        opts = initOptions(options, opts);
+
+        if(!opts.str){
+            throw new Error('A parameter is required to return an md5 hash.');
+        }
+
+        return this.bimd5.md5(opts.str, opts.key, opts.raw);
+    };
 
     var data = {
 
@@ -1991,6 +2100,10 @@
         return new MersenneTwister(seed);
     };
 
+    Chance.prototype.blueimp_md5 = function () {
+        return new BlueImpMD5();
+    };
+
     // Mersenne Twister from https://gist.github.com/banksean/300494
     var MersenneTwister = function (seed) {
         if (seed === undefined) {
@@ -2119,6 +2232,254 @@
         return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0);
     };
 
+    // BlueImp MD5 hashing algorithm from https://github.com/blueimp/JavaScript-MD5
+    var BlueImpMD5 = function () {};
+
+    BlueImpMD5.prototype.VERSION = '1.0.1';
+
+    /*
+    * Add integers, wrapping at 2^32. This uses 16-bit operations internally
+    * to work around bugs in some JS interpreters.
+    */
+    BlueImpMD5.prototype.safe_add = function safe_add(x, y) {
+        var lsw = (x & 0xFFFF) + (y & 0xFFFF),
+            msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+        return (msw << 16) | (lsw & 0xFFFF);
+    };
+
+    /*
+    * Bitwise rotate a 32-bit number to the left.
+    */
+    BlueImpMD5.prototype.bit_roll = function (num, cnt) {
+        return (num << cnt) | (num >>> (32 - cnt));
+    };
+
+    /*
+    * These functions implement the five basic operations the algorithm uses.
+    */
+    BlueImpMD5.prototype.md5_cmn = function (q, a, b, x, s, t) {
+        return this.safe_add(this.bit_roll(this.safe_add(this.safe_add(a, q), this.safe_add(x, t)), s), b);
+    };
+    BlueImpMD5.prototype.md5_ff = function (a, b, c, d, x, s, t) {
+        return this.md5_cmn((b & c) | ((~b) & d), a, b, x, s, t);
+    };
+    BlueImpMD5.prototype.md5_gg = function (a, b, c, d, x, s, t) {
+        return this.md5_cmn((b & d) | (c & (~d)), a, b, x, s, t);
+    };
+    BlueImpMD5.prototype.md5_hh = function (a, b, c, d, x, s, t) {
+        return this.md5_cmn(b ^ c ^ d, a, b, x, s, t);
+    };
+    BlueImpMD5.prototype.md5_ii = function (a, b, c, d, x, s, t) {
+        return this.md5_cmn(c ^ (b | (~d)), a, b, x, s, t);
+    };
+
+    /*
+    * Calculate the MD5 of an array of little-endian words, and a bit length.
+    */
+    BlueImpMD5.prototype.binl_md5 = function (x, len) {
+        /* append padding */
+        x[len >> 5] |= 0x80 << (len % 32);
+        x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+        var i, olda, oldb, oldc, oldd,
+            a =  1732584193,
+            b = -271733879,
+            c = -1732584194,
+            d =  271733878;
+
+        for (i = 0; i < x.length; i += 16) {
+            olda = a;
+            oldb = b;
+            oldc = c;
+            oldd = d;
+
+            a = this.md5_ff(a, b, c, d, x[i],       7, -680876936);
+            d = this.md5_ff(d, a, b, c, x[i +  1], 12, -389564586);
+            c = this.md5_ff(c, d, a, b, x[i +  2], 17,  606105819);
+            b = this.md5_ff(b, c, d, a, x[i +  3], 22, -1044525330);
+            a = this.md5_ff(a, b, c, d, x[i +  4],  7, -176418897);
+            d = this.md5_ff(d, a, b, c, x[i +  5], 12,  1200080426);
+            c = this.md5_ff(c, d, a, b, x[i +  6], 17, -1473231341);
+            b = this.md5_ff(b, c, d, a, x[i +  7], 22, -45705983);
+            a = this.md5_ff(a, b, c, d, x[i +  8],  7,  1770035416);
+            d = this.md5_ff(d, a, b, c, x[i +  9], 12, -1958414417);
+            c = this.md5_ff(c, d, a, b, x[i + 10], 17, -42063);
+            b = this.md5_ff(b, c, d, a, x[i + 11], 22, -1990404162);
+            a = this.md5_ff(a, b, c, d, x[i + 12],  7,  1804603682);
+            d = this.md5_ff(d, a, b, c, x[i + 13], 12, -40341101);
+            c = this.md5_ff(c, d, a, b, x[i + 14], 17, -1502002290);
+            b = this.md5_ff(b, c, d, a, x[i + 15], 22,  1236535329);
+
+            a = this.md5_gg(a, b, c, d, x[i +  1],  5, -165796510);
+            d = this.md5_gg(d, a, b, c, x[i +  6],  9, -1069501632);
+            c = this.md5_gg(c, d, a, b, x[i + 11], 14,  643717713);
+            b = this.md5_gg(b, c, d, a, x[i],      20, -373897302);
+            a = this.md5_gg(a, b, c, d, x[i +  5],  5, -701558691);
+            d = this.md5_gg(d, a, b, c, x[i + 10],  9,  38016083);
+            c = this.md5_gg(c, d, a, b, x[i + 15], 14, -660478335);
+            b = this.md5_gg(b, c, d, a, x[i +  4], 20, -405537848);
+            a = this.md5_gg(a, b, c, d, x[i +  9],  5,  568446438);
+            d = this.md5_gg(d, a, b, c, x[i + 14],  9, -1019803690);
+            c = this.md5_gg(c, d, a, b, x[i +  3], 14, -187363961);
+            b = this.md5_gg(b, c, d, a, x[i +  8], 20,  1163531501);
+            a = this.md5_gg(a, b, c, d, x[i + 13],  5, -1444681467);
+            d = this.md5_gg(d, a, b, c, x[i +  2],  9, -51403784);
+            c = this.md5_gg(c, d, a, b, x[i +  7], 14,  1735328473);
+            b = this.md5_gg(b, c, d, a, x[i + 12], 20, -1926607734);
+
+            a = this.md5_hh(a, b, c, d, x[i +  5],  4, -378558);
+            d = this.md5_hh(d, a, b, c, x[i +  8], 11, -2022574463);
+            c = this.md5_hh(c, d, a, b, x[i + 11], 16,  1839030562);
+            b = this.md5_hh(b, c, d, a, x[i + 14], 23, -35309556);
+            a = this.md5_hh(a, b, c, d, x[i +  1],  4, -1530992060);
+            d = this.md5_hh(d, a, b, c, x[i +  4], 11,  1272893353);
+            c = this.md5_hh(c, d, a, b, x[i +  7], 16, -155497632);
+            b = this.md5_hh(b, c, d, a, x[i + 10], 23, -1094730640);
+            a = this.md5_hh(a, b, c, d, x[i + 13],  4,  681279174);
+            d = this.md5_hh(d, a, b, c, x[i],      11, -358537222);
+            c = this.md5_hh(c, d, a, b, x[i +  3], 16, -722521979);
+            b = this.md5_hh(b, c, d, a, x[i +  6], 23,  76029189);
+            a = this.md5_hh(a, b, c, d, x[i +  9],  4, -640364487);
+            d = this.md5_hh(d, a, b, c, x[i + 12], 11, -421815835);
+            c = this.md5_hh(c, d, a, b, x[i + 15], 16,  530742520);
+            b = this.md5_hh(b, c, d, a, x[i +  2], 23, -995338651);
+
+            a = this.md5_ii(a, b, c, d, x[i],       6, -198630844);
+            d = this.md5_ii(d, a, b, c, x[i +  7], 10,  1126891415);
+            c = this.md5_ii(c, d, a, b, x[i + 14], 15, -1416354905);
+            b = this.md5_ii(b, c, d, a, x[i +  5], 21, -57434055);
+            a = this.md5_ii(a, b, c, d, x[i + 12],  6,  1700485571);
+            d = this.md5_ii(d, a, b, c, x[i +  3], 10, -1894986606);
+            c = this.md5_ii(c, d, a, b, x[i + 10], 15, -1051523);
+            b = this.md5_ii(b, c, d, a, x[i +  1], 21, -2054922799);
+            a = this.md5_ii(a, b, c, d, x[i +  8],  6,  1873313359);
+            d = this.md5_ii(d, a, b, c, x[i + 15], 10, -30611744);
+            c = this.md5_ii(c, d, a, b, x[i +  6], 15, -1560198380);
+            b = this.md5_ii(b, c, d, a, x[i + 13], 21,  1309151649);
+            a = this.md5_ii(a, b, c, d, x[i +  4],  6, -145523070);
+            d = this.md5_ii(d, a, b, c, x[i + 11], 10, -1120210379);
+            c = this.md5_ii(c, d, a, b, x[i +  2], 15,  718787259);
+            b = this.md5_ii(b, c, d, a, x[i +  9], 21, -343485551);
+
+            a = this.safe_add(a, olda);
+            b = this.safe_add(b, oldb);
+            c = this.safe_add(c, oldc);
+            d = this.safe_add(d, oldd);
+        }
+        return [a, b, c, d];
+    };
+
+    /*
+    * Convert an array of little-endian words to a string
+    */
+    BlueImpMD5.prototype.binl2rstr = function (input) {
+        var i,
+            output = '';
+        for (i = 0; i < input.length * 32; i += 8) {
+            output += String.fromCharCode((input[i >> 5] >>> (i % 32)) & 0xFF);
+        }
+        return output;
+    };
+
+    /*
+    * Convert a raw string to an array of little-endian words
+    * Characters >255 have their high-byte silently ignored.
+    */
+    BlueImpMD5.prototype.rstr2binl = function (input) {
+        var i,
+            output = [];
+        output[(input.length >> 2) - 1] = undefined;
+        for (i = 0; i < output.length; i += 1) {
+            output[i] = 0;
+        }
+        for (i = 0; i < input.length * 8; i += 8) {
+            output[i >> 5] |= (input.charCodeAt(i / 8) & 0xFF) << (i % 32);
+        }
+        return output;
+    };
+
+    /*
+    * Calculate the MD5 of a raw string
+    */
+    BlueImpMD5.prototype.rstr_md5 = function (s) {
+        return this.binl2rstr(this.binl_md5(this.rstr2binl(s), s.length * 8));
+    };
+
+    /*
+    * Calculate the HMAC-MD5, of a key and some data (raw strings)
+    */
+    BlueImpMD5.prototype.rstr_hmac_md5 = function (key, data) {
+        var i,
+            bkey = this.rstr2binl(key),
+            ipad = [],
+            opad = [],
+            hash;
+        ipad[15] = opad[15] = undefined;
+        if (bkey.length > 16) {
+            bkey = this.binl_md5(bkey, key.length * 8);
+        }
+        for (i = 0; i < 16; i += 1) {
+            ipad[i] = bkey[i] ^ 0x36363636;
+            opad[i] = bkey[i] ^ 0x5C5C5C5C;
+        }
+        hash = this.binl_md5(ipad.concat(this.rstr2binl(data)), 512 + data.length * 8);
+        return this.binl2rstr(this.binl_md5(opad.concat(hash), 512 + 128));
+    };
+
+    /*
+    * Convert a raw string to a hex string
+    */
+    BlueImpMD5.prototype.rstr2hex = function (input) {
+        var hex_tab = '0123456789abcdef',
+            output = '',
+            x,
+            i;
+        for (i = 0; i < input.length; i += 1) {
+            x = input.charCodeAt(i);
+            output += hex_tab.charAt((x >>> 4) & 0x0F) +
+                hex_tab.charAt(x & 0x0F);
+        }
+        return output;
+    };
+
+    /*
+    * Encode a string as utf-8
+    */
+    BlueImpMD5.prototype.str2rstr_utf8 = function (input) {
+        return unescape(encodeURIComponent(input));
+    };
+
+    /*
+    * Take string arguments and return either raw or hex encoded strings
+    */
+    BlueImpMD5.prototype.raw_md5 = function (s) {
+        return this.rstr_md5(this.str2rstr_utf8(s));
+    };
+    BlueImpMD5.prototype.hex_md5 = function (s) {
+        return this.rstr2hex(this.raw_md5(s));
+    };
+    BlueImpMD5.prototype.raw_hmac_md5 = function (k, d) {
+        return this.rstr_hmac_md5(this.str2rstr_utf8(k), this.str2rstr_utf8(d));
+    };
+    BlueImpMD5.prototype.hex_hmac_md5 = function (k, d) {
+        return this.rstr2hex(this.raw_hmac_md5(k, d));
+    };
+
+    BlueImpMD5.prototype.md5 = function (string, key, raw) {
+        if (!key) {
+            if (!raw) {
+                return this.hex_md5(string);
+            }
+
+            return this.raw_md5(string);
+        }
+
+        if (!raw) {
+            return this.hex_hmac_md5(key, string);
+        }
+
+        return this.raw_hmac_md5(key, string);
+    };
 
     // CommonJS module
     if (typeof exports !== 'undefined') {

--- a/chance.js
+++ b/chance.js
@@ -1580,9 +1580,13 @@
 
     // MD5 Hash
     Chance.prototype.md5 = function(options) {
-        var opts = { str: "", key: null, raw: false };
+        var opts = { str: '', key: null, raw: false };
 
-        if(typeof options === 'string') {
+        if (!options) {
+            opts.str = this.string();
+            options = {};
+        }
+        else if (typeof options === 'string') {
             opts.str = options;
             options = {};
         }

--- a/test/test.web.js
+++ b/test/test.web.js
@@ -413,6 +413,11 @@ describe("Web", function () {
     });
 
     describe('md5()', function () {
+        it('should create a hex-encoded MD5 hash of a random ASCII value when passed nothing', function () {
+            var md5 = chance.md5();
+            expect(md5.length).to.be.eql('2063c1608d6e0baf80249c42e2be5804'.length);
+        });
+
         it('should create a hex-encoded MD5 hash of an ASCII value when passed a string', function () {
             expect(chance.md5('value')).to.be.eql('2063c1608d6e0baf80249c42e2be5804');
         });

--- a/test/test.web.js
+++ b/test/test.web.js
@@ -4,7 +4,136 @@
 var expect = chai.expect;
 
 describe("Web", function () {
-    var tld, domain, email, hashtag, ip, ipv6, tracking_code, twitter, url, chance = new Chance();
+    var avatar, tld, domain, email, hashtag, ip, ipv6, tracking_code, twitter, url, chance = new Chance();
+
+    describe("avatar()", function() {
+        it("returns a legit avatar", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar();
+                expect(avatar).to.be.a('string');
+                expect(avatar.split('/').length).to.equal(5);
+            });
+        });
+
+        it("can take and ignore an invalid protocol", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar({ protocol: 'invalid' });
+                expect(avatar).to.be.a('string');
+                expect(avatar.indexOf('//')).to.eql(0);
+            });
+        });
+
+        it("can take and respect a protocol", function () {
+            var PROTOCOLS = [
+                'http',
+                'https'
+            ];
+            _(500).times(function () {
+                _(PROTOCOLS.length).times(function(n){
+                    avatar = chance.avatar({ protocol: PROTOCOLS[n] });
+                    expect(avatar).to.be.a('string');
+                    expect(avatar.indexOf(PROTOCOLS[n] + ':')).to.eql(0);
+                });
+            });
+        });
+
+        it("can take and respect an email", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar({ email: chance.email() });
+                expect(avatar).to.be.a('string');
+                expect(avatar.split('/').length).to.eql(5);
+            });
+        });
+
+
+        it("can take and ignore an invalid fileExtension", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar({ fileExtension: 'invalid' });
+                expect(avatar).to.be.a('string');
+                expect(avatar).to.not.contain('.jpg');
+                expect(avatar).to.not.contain('.bmp');
+                expect(avatar).to.not.contain('.png');
+            });
+        });
+
+        it("can take and respect a fileExtension", function () {
+            var FILE_TYPES = [
+                'bmp',
+                'gif',
+                'jpg',
+                'png'
+            ];
+            _(250).times(function () {
+                _(FILE_TYPES.length).times(function(n){
+                    avatar = chance.avatar({ fileExtension: FILE_TYPES[n] });
+                    expect(avatar).to.be.a('string');
+                    expect(avatar).to.contain('.' + FILE_TYPES[n]);
+                });
+            });
+        });
+
+        it("can take and ignore an invalid size", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar({ size: 'abc' });
+                expect(avatar).to.be.a('string');
+                expect(avatar).to.not.contain('&s=');
+            });
+        });
+
+        it("can take and respect a size", function () {
+            _(1000).times(function (n) {
+                avatar = chance.avatar({ size: n + 1 });
+                expect(avatar).to.be.a('string');
+                expect(avatar).to.contain('&s=' + (n + 1).toString());
+            });
+        });
+
+        it("can take and ignore an invalid rating", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar({ rating: 'invalid' });
+                expect(avatar).to.be.a('string');
+                expect(avatar).to.not.contain('&r=');
+            });
+        });
+
+        it("can take and respect a rating", function () {
+            var RATINGS = ['g', 'pg', 'r', 'x'];
+            _(250).times(function(){
+                _(RATINGS.length).times(function (n) {
+                    avatar = chance.avatar({ rating: RATINGS[n] });
+                    expect(avatar).to.be.a('string');
+                    expect(avatar).to.contain('&r=' + RATINGS[n].toString());
+                });
+            });
+        });
+
+        it("can take and ignore an invalid fallback image", function () {
+            _(1000).times(function () {
+                avatar = chance.avatar({ fallback: 'invalid' });
+                expect(avatar).to.be.a('string');
+                expect(avatar).to.not.contain('&d=');
+            });
+        });
+
+        it("can take and respect a fallback image", function () {
+            var FALLBACKS = [
+                '404', // Return 404 if not found
+                'mm', // Mystery man
+                'identicon', // Geometric pattern based on hash
+                'monsterid', // A generated monster icon
+                'wavatar', // A generated face
+                'retro', // 8-bit icon
+                'blank' // A transparent png
+            ];
+            _(100).times(function(){
+                _(FALLBACKS.length).times(function (n) {
+                    avatar = chance.avatar({ fallback: FALLBACKS[n] });
+                    expect(avatar).to.be.a('string');
+                    expect(avatar).to.contain('&d=' + FALLBACKS[n].toString());
+                });
+            });
+        });
+    });
 
     it("tld() returns a tld", function () {
         _(1000).times(function () {
@@ -282,4 +411,43 @@ describe("Web", function () {
             });
         });
     });
+
+    describe('md5()', function () {
+        it('should create a hex-encoded MD5 hash of an ASCII value when passed a string', function () {
+            expect(chance.md5('value')).to.be.eql('2063c1608d6e0baf80249c42e2be5804');
+        });
+
+        it('should create a hex-encoded MD5 hash of an ASCII value when passed an object', function () {
+            expect(chance.md5({ str: 'value' })).to.be.eql('2063c1608d6e0baf80249c42e2be5804');
+        });
+
+        it('should create a hex-encoded MD5 hash of an UTF-8 value', function () {
+            expect(chance.md5('日本')).to.be.eql('4dbed2e657457884e67137d3514119b3');
+        });
+
+        it('should create a hex-encoded HMAC-MD5 hash of an ASCII value and key', function () {
+            expect(chance.md5({ str: 'value', key: 'key' })).to.be.eql('01433efd5f16327ea4b31144572c67f6');
+        });
+
+        it('should create a hex-encoded HMAC-MD5 hash of an UTF-8 value and key', function () {
+            expect(chance.md5({ str: '日本', key: '日本' })).to.be.eql('c78b8c7357926981cc04740bd3e9d015');
+        });
+
+        it('should create a raw MD5 hash of an ASCII value', function () {
+            expect(chance.md5({ str: 'value', key: null, raw: true })).to.be.eql(' c\xc1`\x8dn\x0b\xaf\x80$\x9cB\xe2\xbeX\x04');
+        });
+
+        it('should create a raw MD5 hash of an UTF-8 value', function () {
+            expect(chance.md5({ str: '日本', key: null, raw: true })).to.be.eql('M\xbe\xd2\xe6WEx\x84\xe6q7\xd3QA\x19\xb3');
+        });
+
+        it('should create a raw HMAC-MD5 hash of an ASCII value and key', function () {
+            expect(chance.md5({ str: 'value', key: 'key', raw: true })).to.be.eql('\x01C>\xfd_\x162~\xa4\xb3\x11DW,g\xf6');
+        });
+
+        it('should create a raw HMAC-MD5 hash of an UTF-8 value and key', function () {
+            expect(chance.md5({ str: '日本', key: '日本', raw: true })).to.be.eql('\xc7\x8b\x8csW\x92i\x81\xcc\x04t\x0b\xd3\xe9\xd0\x15');
+        });
+    });
+
 });


### PR DESCRIPTION
Include a way to easily generate md5 hashes and (gr)avatar urls.

Sample usage:

```javascript
// md5()
chance.md5(); // = <random hash>
chance.md5('value'); // = 2063c1608d6e0baf80249c42e2be5804

// md5() w/all options
chance.md5({ str: 'value', key: 'key', raw: true }); // = 'C>ý_2~¤³DW,gö

// avatar()
chance.avatar(); // = //www.gravatar.com/avatar/<random hash>
chance.avatar('email@test.com'); // = //www.gravatar.com/avatar/f1f97cfa813c828a73528989da671a81

// avatar() w/all options
chance.avatar({
  email: 'email@test.com', 
  protocol: 'https', // http or https. Otherwise client determinate.
  fileExtension: 'png', // bmp, gif, or jpg. Otherwise no specification.
  rating: 'g', // g, pg, r, or x. Otherwise no specification.
  fallback: 'retro', // 404, mm, identicon, monsterid, wavatar, retro, or blank. Otherwise no specification.
  size: 80 // Integer determining the height and width. Must be positive.
}); // = https://www.gravatar.com/avatar/f1f97cfa813c828a73528989da671a81.png?&r=g&d=retro&s=80
```