### PR TITLE
Bug/exp not honoring future date

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1476,13 +1476,14 @@
     Chance.prototype.exp_month = function (options) {
         options = initOptions(options);
         var month, month_int,
-            curMonth = new Date().getMonth();
+            // Date object months are 0 indexed
+            curMonth = new Date().getMonth() + 1;
 
         if (options.future) {
             do {
                 month = this.month({raw: true}).numeric;
                 month_int = parseInt(month, 10);
-            } while (month_int < curMonth);
+            } while (month_int <= curMonth);
         } else {
             month = this.month({raw: true}).numeric;
         }

--- a/chance.js
+++ b/chance.js
@@ -1464,7 +1464,7 @@
 
         // If the year is this year, need to ensure month is greater than the
         // current month or this expiration will not be valid
-        if (exp.year === (new Date().getFullYear())) {
+        if (exp.year === (new Date().getFullYear()).toString()) {
             exp.month = this.exp_month({future: true});
         } else {
             exp.month = this.exp_month();

--- a/test/test.finance.js
+++ b/test/test.finance.js
@@ -167,6 +167,25 @@ describe("Credit Card", function () {
             });
         });
 
+        it("exp() returns a valid credit card expiration date (ie a future date)", function () {
+            _(1000).times(function () {
+                exp = chance.exp({raw: true});
+
+                var now = new Date();
+                var nowMonth = now.getMonth() + 1;
+                var nowYear = now.getFullYear();
+                var expMonth = parseInt(exp.month, 10);
+                var expYear = parseInt(exp.year, 10);
+
+                expect(expYear).to.be.at.least(nowYear);
+
+                if(expYear === nowYear) {
+                    expect(expMonth).to.be.above(nowMonth);
+                }
+
+            });
+        });
+
         it("exp_month() returns a numeric month with leading 0", function () {
             _(1000).times(function () {
                 month = chance.exp_month();

--- a/test/test.finance.js
+++ b/test/test.finance.js
@@ -181,5 +181,14 @@ describe("Credit Card", function () {
                 expect(year).to.be.within(new Date().getFullYear(), new Date().getFullYear() + 10);
             });
         });
+
+        it("exp_month() will return a future month if passed {future: true}", function () {
+            _(1000).times(function () {
+                var nowMonth = new Date().getMonth() + 1;
+                var expMonth = parseInt(chance.exp_month({ future: true }), 10);
+
+                expect(expMonth).to.be.above(nowMonth);
+            });
+        });        
     });
 });


### PR DESCRIPTION
Both `exp()` and `exp_month({future: true})` failed to generate future dates.