### PR TITLE
Change or remove punctuation mark from sentence

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -462,12 +462,19 @@
         options = initOptions(options);
 
         var words = options.words || this.natural({min: 12, max: 18}),
+            punctuation = options.punctuation,
             text, word_array = this.n(this.word, words);
 
         text = word_array.join(' ');
-
-        // Capitalize first letter of sentence, add period at end
-        text = this.capitalize(text) + '.';
+        
+        // Capitalize first letter of sentence
+        text = this.capitalize(text);
+        
+        // Make sure punctuation has a usable value
+        if (punctuation !== false && !/^[\.\?;!:]$/.test(punctuation)) punctuation = '.';
+        
+        // Add punctuation mark
+        if (punctuation) text += punctuation;
 
         return text;
     };

--- a/chance.js
+++ b/chance.js
@@ -471,10 +471,14 @@
         text = this.capitalize(text);
         
         // Make sure punctuation has a usable value
-        if (punctuation !== false && !/^[\.\?;!:]$/.test(punctuation)) punctuation = '.';
+        if (punctuation !== false && !/^[\.\?;!:]$/.test(punctuation)) {
+            punctuation = '.';
+        }
         
         // Add punctuation mark
-        if (punctuation) text += punctuation;
+        if (punctuation) {
+            text += punctuation;
+        }
 
         return text;
     };


### PR DESCRIPTION
In using this library, I thought it would be nice to add in an option to change and/or remove the punctuation mark at the end of a sentence. This would make it ideal for generating random things like alert messages that you may want to have end with an exclamation mark instead of a period, or page titles where you may want no punctuation mark at all.