### PR TITLE
Fixed color base types

### DIFF
--- a/web/_posts/1900-01-01-color.md
+++ b/web/_posts/1900-01-01-color.md
@@ -14,7 +14,7 @@ chance.color()
 => '#79c157'
 {% endhighlight %}
 
-Colors have three base types: `hex`, `shorthex`, `rgb`, '0x'
+Colors have four base types: `hex`, `shorthex`, `rgb`, `0x`
 
 These are the kinds usable in HTML or CSS. The type can optionally be specified
 


### PR DESCRIPTION
Fixed markdown for '0x', and changed `three` to `four`