### PR TITLE
Add "pool" capability to normal() function

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -2331,7 +2331,18 @@
     };
 
     Chance.prototype.normal = function (options) {
-        options = initOptions(options, {mean : 0, dev : 1});
+        options = initOptions(options, {mean : 0, dev : 1, pool : []});
+
+        testRange(
+            options.pool.constructor !== Array,
+            "Chance: The pool option must be a valid array."
+        );
+
+        // If a pool has been passed, then we are returning an item from that pool,
+        // using the normal distribution settings that were passed in
+        if (options.pool.length > 0) {
+            return this.normal_pool(options);
+        }
 
         // The Marsaglia Polar method
         var s, u, v, norm,
@@ -2351,6 +2362,20 @@
 
         // Shape and scale
         return dev * norm + mean;
+    };
+
+    Chance.prototype.normal_pool = function(options) {
+        var performanceCounter = 0;
+        do {
+            var idx = Math.round(this.normal({ mean: options.mean, dev: options.dev }));
+            if (idx < options.pool.length && idx >= 0) {
+                return options.pool[idx];
+            } else {
+                performanceCounter++;
+            }
+        } while(performanceCounter < 100);
+
+        throw new RangeError("Chance: Your pool is too small for the given mean and standard deviation. Please adjust.");
     };
 
     Chance.prototype.radio = function (options) {

--- a/test/test.normal.js
+++ b/test/test.normal.js
@@ -95,18 +95,16 @@ describe("Normal Distribution", function () {
             stddev = 2;
             mean = 6;
 
-            _(10).times(function () {
-                group = chance.n(chance.normal, 10000, {mean: mean, dev: stddev, pool: pool});
-                var counts = _.countBy(group);
+            group = chance.n(chance.normal, 10000, {mean: mean, dev: stddev, pool: pool});
+            var counts = _.countBy(group);
 
-                expect(counts["Sunday"])
-                    .to.be.above(counts["Saturday"])
-                    .to.be.above(counts["Friday"])
-                    .to.be.above(counts["Thursday"])
-                    .to.be.above(counts["Wednesday"])
-                    .to.be.above(counts["Tuesday"])
-                    .to.be.above(counts["Monday"]);
-            });
+            expect(counts["Sunday"])
+                .to.be.above(counts["Saturday"])
+                .to.be.above(counts["Friday"])
+                .to.be.above(counts["Thursday"])
+                .to.be.above(counts["Wednesday"])
+                .to.be.above(counts["Tuesday"])
+                .to.be.above(counts["Monday"]);
         });
 
         it("should throw an error quickly if the user has provided bad pool/mean/dev values", function () {

--- a/test/test.normal.js
+++ b/test/test.normal.js
@@ -35,7 +35,7 @@ describe("Normal Distribution", function () {
             group = chance.n(chance.normal, 10000);
 
             expect(Math.abs(Math.mean(group) - mean)).to.be.below(stddev);
-            expect(Math.abs(Math.stddev(group) - stddev)).to.be.below(stddev *.05);
+            expect(Math.abs(Math.stddev(group) - stddev)).to.be.below(stddev *0.05);
         });
     });
 
@@ -56,7 +56,7 @@ describe("Normal Distribution", function () {
             group = chance.n(chance.normal, 10000, { mean: mean, dev: stddev});
 
             expect(Math.abs(Math.mean(group) - mean)).to.be.below(stddev);
-            expect(Math.abs(Math.stddev(group) - stddev)).to.be.below(stddev *.05);
+            expect(Math.abs(Math.stddev(group) - stddev)).to.be.below(stddev *0.05);
         });
     });
 
@@ -125,6 +125,19 @@ describe("Normal Distribution", function () {
             };
 
             expect(fn).to.throw(RangeError);
+        });
+
+        it("should work with objects", function () {
+            stddev = 1;
+            mean = 1;
+            group = chance.n(chance.normal, 50, { mean: mean, dev: stddev, pool: [
+                { a: 1, b: 10},
+                { a: 2, b: 20},
+                { a: 3, b: 30}
+            ]});
+
+            expect(group).to.have.length(50);
+            expect(group[0]).to.include.keys('a');
         });
 
     });

--- a/test/test.normal.js
+++ b/test/test.normal.js
@@ -1,0 +1,124 @@
+/* jshint newcap:false */
+/// <reference path="../chance.js" />
+/// <reference path="../node_modules/underscore/underscore-min.js" />
+
+var expect = chai.expect;
+
+describe("Normal Distribution", function () {
+    var mean, stddev, norm, group, chance = new Chance();
+    var pool = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+    Math.mean = function(arr){
+        return arr.reduce(function(a, b){return a+b;})/arr.length;
+    };
+
+    Math.stddev = function(arr){
+        var mean = Math.mean(arr),
+            deviation = arr.map(function(item){return (item-mean)*(item-mean);});
+        return Math.sqrt(deviation.reduce(function(a, b){return a+b;})/arr.length);
+    };
+
+    describe("normal() works as expected with no parameters", function () {
+        it("returns a number", function () {
+            stddev = 1;
+            mean = 0;
+
+            _(1000).times(function () {
+                norm = chance.normal();
+                expect(norm).to.be.a('number');
+            });
+        });
+
+        it("returns values fairly close to the expected standard deviation and mean", function () {
+            stddev = 1;
+            mean = 0;
+            group = chance.n(chance.normal, 10000);
+
+            expect(Math.abs(Math.mean(group) - mean)).to.be.below(stddev);
+            expect(Math.abs(Math.stddev(group) - stddev)).to.be.below(stddev *.05);
+        });
+    });
+
+    describe("normal() works as expected with a custom mean and standard deviation", function () {
+        it("returns a number", function () {
+            stddev = 5;
+            mean = 10;
+
+            _(1000).times(function () {
+                norm = chance.normal({ mean: mean, dev: stddev});
+                expect(norm).to.be.a('number');
+            });
+        });
+
+        it("returns values fairly close to the expected standard deviation and mean", function () {
+            stddev = 5;
+            mean = 10;
+            group = chance.n(chance.normal, 10000, { mean: mean, dev: stddev});
+
+            expect(Math.abs(Math.mean(group) - mean)).to.be.below(stddev);
+            expect(Math.abs(Math.stddev(group) - stddev)).to.be.below(stddev *.05);
+        });
+    });
+
+    describe("normal() works as expected with a pool of custom values provided", function () {
+        it("returns a string from a pool if passed a pool of strings", function () {
+            stddev = 0.0000000001;
+            mean = 2;
+
+            _(1000).times(function () {
+                norm = chance.normal({ mean: mean, dev: stddev, pool: pool});
+                expect(pool).to.include(norm);
+            });
+        });
+
+        it("recalculates and returns a value even if the normal() results in indexes outside the bounds of the pool", function () {
+            stddev = 1.5;
+            mean = 3;
+
+            _(1000).times(function () {
+                norm = chance.normal({ mean: mean, dev: stddev, pool: pool});
+                expect(pool).to.include(norm);
+            });
+        });
+
+        it("can be used with other chance functions", function () {
+            stddev = 1;
+            mean = 3;
+            group = chance.n(chance.normal, 1000, { mean: mean, dev: stddev, pool: pool});
+
+            expect(group).to.have.length(1000);
+            expect(pool).to.include(group[0]);
+            expect(pool).to.include(group[999]);
+        });
+
+        it("should produce a correctly distributed group of pool items", function () {
+            stddev = 2;
+            mean = 6;
+
+            _(10).times(function () {
+                group = chance.n(chance.normal, 10000, {mean: mean, dev: stddev, pool: pool});
+                var counts = _.countBy(group);
+
+                expect(counts["Sunday"])
+                    .to.be.above(counts["Saturday"])
+                    .to.be.above(counts["Friday"])
+                    .to.be.above(counts["Thursday"])
+                    .to.be.above(counts["Wednesday"])
+                    .to.be.above(counts["Tuesday"])
+                    .to.be.above(counts["Monday"]);
+            });
+        });
+
+        it("should throw an error quickly if the user has provided bad pool/mean/dev values", function () {
+            stddev = 5;
+            mean = 200;
+            var fn = function() {
+                chance.normal({ mean: mean, dev: stddev, pool: pool});
+            };
+
+            expect(fn).to.throw(RangeError);
+        });
+
+    });
+
+});

--- a/test/test.normal.js
+++ b/test/test.normal.js
@@ -119,6 +119,14 @@ describe("Normal Distribution", function () {
             expect(fn).to.throw(RangeError);
         });
 
+        it("should throw an error if the pool provided is not an array", function () {
+            var fn = function() {
+                chance.normal({ pool: 'not an array'});
+            };
+
+            expect(fn).to.throw(RangeError);
+        });
+
     });
 
 });


### PR DESCRIPTION
# Add "pool" capability to normal() function

Hi All. This new functionality would allow users to generate values other than numbers, but still based on the probabilities of a normal distribution. For example, let's say you were generating fake data for a vehicle manufacturer which makes 20 different models of cars and you wanted to generate those models based on a standard distribution pattern. Some of those models would be rare and others would be much more common. You can now do that by supplying a "pool" of values to the normal function:

```javascript
chance.normal({ mean: 9, dev: 3, pool: ['WRX', 'XV', 'BRZ', 'X', 'etc...'] });
```
Or in the case where you wanted a large array of them:
```javascript
chance.n(chance.normal, 1000, { mean: 9, dev: 3, pool: ['WRX', 'XV', 'BRZ', 'X', 'etc...'] });
```

This makes it slightly easier than the "weighted" method in certain situations because you don't have to explicitly set the weights for each individual item in the array. Imagine having 100+ unique values and needing to calculate and set weights for each item individually, when you really just want a normal distribution of those values.

##### This is my first contribution to an open-source project ever!  :+1: 