### PR TITLE
Adds capitalize option to word and syllable

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -540,6 +540,10 @@
 
             text += chr;
         }
+        
+        if (options.capitalize) {
+            text = this.capitalize(text);   
+        }
 
         return text;
     };
@@ -567,6 +571,11 @@
                 text += this.syllable();
             }
         }
+        
+        if (options.capitalize) {
+            text = this.capitalize(text);   
+        }
+        
         return text;
     };
 


### PR DESCRIPTION
Allow capitalize to be passed as an option to `word` or `syllable` methods.