### PR TITLE
Fix chance.file() using chance.word internally instead of this.word

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1887,7 +1887,7 @@
         var fileExtention;
 
         // Generate random file name 
-        fileName = chance.word({length : fileOptions.length});
+        fileName = this.word({length : fileOptions.length});
 
         // Generate file by specific extention provided by the user
         if(fileOptions.extention) {


### PR DESCRIPTION
Fixes chance.file() not working properly when a definition other than chance is used.